### PR TITLE
refactor(vue): remove unnecessary defineProps import

### DIFF
--- a/src/content/Backgrounds/Ballpit/Ballpit.vue
+++ b/src/content/Backgrounds/Ballpit/Ballpit.vue
@@ -26,7 +26,7 @@ import {
   type WebGLRendererParameters
 } from 'three';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
-import { defineProps, onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 
 gsap.registerPlugin(Observer);
 


### PR DESCRIPTION
The `defineProps` macro is automatically available in `<script setup>` and no longer needs to be imported. This commit removes the redundant import statements to align with modern Vue best practices and resolve compiler warnings.