### PR TITLE
Fix staggerFrom prop syntax in rotatingTextCode.ts

### DIFF
--- a/src/constants/code/TextAnimations/rotatingTextCode.ts
+++ b/src/constants/code/TextAnimations/rotatingTextCode.ts
@@ -7,7 +7,7 @@ export const rotatingText = createCodeObject(code, 'TextAnimations/RotatingText'
     <RotatingText
       :texts="['Vue', 'Bits', 'is', 'Cool!']"
       mainClassName="px-2 sm:px-2 md:px-3 bg-green-300 text-black overflow-hidden py-0.5 sm:py-1 md:py-2 justify-center rounded-lg"
-      :staggerFrom="last"
+      :staggerFrom="'last'"
       :initial="{ y: '100%' }"
       :animate="{ y: 0 }"
       :exit="{ y: '-120%' }"


### PR DESCRIPTION
https://github.com/DavidHDev/vue-bits/issues/108

The code `:staggerFrom="last"` should remove the quotation marks and be changed to `staggerFrom="last"` because `type StaggerFrom = 'first' | 'last' | 'center' | 'random' | number`

If considering whether StaggerFrom can be of numeric type, it should be changed to `:staggerFrom="'last'"`