### PR TITLE
docs: fix CLI heading of jsrepo img

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ These components are all enhanced with customization options as props, to make i
 - All components have minimal dependencies, and are highly customizable through props
 - Designed to integrate seamlessly with any modern Vue/Nuxt project
 
-## CLI (<a href="https://jsrepo.dev"><img src="https://jsrepo.dev/badges/jsrepo.svg" width="50" alt="jsrepo"></a>)
+## CLI [![jsrepo](https://jsrepo.com/badges/@ieedan/std)](https://jsrepo.com/packages/@ieedan/std)
+
 
 Vue Bits uses [jsrepo](https://jsrepo.dev) for installing components via CLI. </br>
 The setup steps can be found on each component's page in the [documentation](https://vue-bits.dev/).


### PR DESCRIPTION
img not show 
<img width="1072" height="628" alt="image" src="https://github.com/user-attachments/assets/f8501fde-fecc-43f0-b8fa-aab2f9c6b06f" />

I see jsrepo found:
<img width="1257" height="909" alt="image" src="https://github.com/user-attachments/assets/d5f6f499-dd2d-437b-ab42-9d7ba57d5d34" />
