### PR TITLE
Fixing Build Error in Rotating Text 

### DIFF
--- a/src/content/TextAnimations/RotatingText/RotatingText.vue
+++ b/src/content/TextAnimations/RotatingText/RotatingText.vue
@@ -80,7 +80,7 @@ const splitIntoCharacters = (text: string): string[] => {
   return [...text];
 };
 const elements = computed((): WordElement[] => {
-  const currentText = props.texts[currentTextIndex.value];
+  const currentText = props.texts[currentTextIndex.value] as string;
 
   switch (props.splitBy) {
     case 'characters': {


### PR DESCRIPTION
Enforcing Type explicitly to avoid build errors caused by Failed Inferred type Casting.