### PR TITLE
Fixed Particles Background racing issue by changing "onMounted"

### DIFF
--- a/src/content/Backgrounds/Particles/Particles.vue
+++ b/src/content/Backgrounds/Particles/Particles.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, useTemplateRef } from 'vue';
+import { ref, onMounted, onUnmounted, watch, useTemplateRef, nextTick } from 'vue';
 import { Renderer, Camera, Geometry, Program, Mesh } from 'ogl';
 
 interface ParticlesProps {
@@ -296,8 +296,10 @@ const cleanup = () => {
   program = null;
 };
 
-onMounted(() => {
-  initParticles();
+// CHANGED onMounted
+onMounted(async () => {
+  await nextTick(); // wait for Vue to flush its DOM updates first
+  initParticles(); 
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## Problem
The Particles Background is blank on page load.

## Why?
 `onMounted` was calling `initParticles()` before Vue flushed its DOM updates, causing a race condition where the container ref wasn't ready yet.

## Fix
Added `await nextTick()` to ensure the DOM is fully available before initialization.